### PR TITLE
Calendar Foundry Game.time Integration

### DIFF
--- a/dolmenwood.mjs
+++ b/dolmenwood.mjs
@@ -68,6 +68,7 @@ Hooks.once('init', async function () {
 	// (game.time.calendar / game.time.components) for module interoperability
 	CONFIG.time.worldCalendarClass = DolmenwoodCalendar
 	CONFIG.time.worldCalendarConfig = buildCalendarConfig()
+	CONFIG.time.formatters.timestamp = DolmenwoodCalendar.formatTimestamp
 	game.dolmenwood = { executeMacroAttack }
 
 	game.settings.register('dolmenwood', 'colorTheme', {

--- a/dolmenwood.mjs
+++ b/dolmenwood.mjs
@@ -16,6 +16,7 @@ import { createSaveLinkEnricher, createChanceLinkEnricher, openInlineSaveModifie
 import WelcomeDialog from './module/welcome-dialog.js'
 import { initCalendarWidget, toggleWidget, handleCalendarSocket } from './module/calendar/calendar-widget.js'
 import { worldTimeToCalendar, dateKeyToEpochDay } from './module/calendar/calendar-time.js'
+import { DolmenwoodCalendar, buildCalendarConfig } from './module/calendar/calendar-data.js'
 import { getFaSymbol, getRuneUsage } from './module/sheet/data-context.js'
 import { registerCombatSystem } from './module/combat/combat.js'
 import { handleCombatSocket } from './module/combat/combat-rolls.js'
@@ -62,6 +63,11 @@ Hooks.on('initializeDynamicTokenRingConfig', ringConfig => {
 Hooks.once('init', async function () {
 	CONFIG.DOLMENWOOD = DOLMENWOOD
 	CONFIG.DOLMENWOOD.effectFields = EFFECT_FIELDS
+
+	// Expose the Dolmenwood calendar through the core time API
+	// (game.time.calendar / game.time.components) for module interoperability
+	CONFIG.time.worldCalendarClass = DolmenwoodCalendar
+	CONFIG.time.worldCalendarConfig = buildCalendarConfig()
 	game.dolmenwood = { executeMacroAttack }
 
 	game.settings.register('dolmenwood', 'colorTheme', {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1107,6 +1107,8 @@
 		"Calendar": {
 			"SettingName": "Show Calendar Widget",
 			"SettingHint": "Display a calendar and time widget above the macro hotbar.",
+			"CalendarName": "Dolmenwood Calendar",
+			"Wysenday": "Wysenday",
 			"Year": "Year",
 			"Month": "Month",
 			"Day": "Day",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -132,6 +132,8 @@
 		"Calendar": {
 			"SettingName": "Pokaż widget kalendarza",
 			"SettingHint": "Wyświetl widget kalendarza i czasu nad paskiem makr.",
+			"CalendarName": "Kalendarz Dolmenwood",
+			"Wysenday": "Wysenday",
 			"Year": "Rok",
 			"Month": "Miesiąc",
 			"Day": "Dzień",

--- a/module/calendar/calendar-data.js
+++ b/module/calendar/calendar-data.js
@@ -1,0 +1,63 @@
+/* global CONFIG, foundry */
+
+/**
+ * Dolmenwood implementation of Foundry's core CalendarData.
+ * Weeks restart each month: days 1-28 are four 7-day weeks; days 29-31
+ * are wysendays, which sit outside the week and are represented as an
+ * 8th pseudo-weekday (index 7).
+ */
+export class DolmenwoodCalendar extends foundry.data.CalendarData {
+	/** @override */
+	timeToComponents(time = 0) {
+		const components = super.timeToComponents(time)
+		components.dayOfWeek = components.dayOfMonth < 28 ? components.dayOfMonth % 7 : 7
+		return components
+	}
+}
+
+/**
+ * Build the core CalendarConfig for game.time.calendar from CONFIG.DOLMENWOOD,
+ * so third-party modules can read the in-world date via the standard API.
+ * Name fields hold i18n keys, matching core's own calendar configuration.
+ */
+export function buildCalendarConfig() {
+	const { BASE_YEAR, DAYS_PER_YEAR, months, seasons, weekDays } = CONFIG.DOLMENWOOD
+	const monthKeys = Object.keys(months)
+
+	const dayValues = weekDays.map((key, i) => ({
+		name: `DOLMEN.Calendar.WeekDays.${key}`,
+		abbreviation: `DOLMEN.Calendar.WeekDaysShort.${key}`,
+		ordinal: i + 1
+	}))
+	dayValues.push({ name: 'DOLMEN.Calendar.Wysenday', ordinal: 8 })
+
+	return {
+		name: 'DOLMEN.Calendar.CalendarName',
+		years: {
+			yearZero: BASE_YEAR,
+			firstWeekday: 0,
+			leapYear: null
+		},
+		months: {
+			values: monthKeys.map((key, i) => ({
+				name: `DOLMEN.Months.${key}`,
+				ordinal: i + 1,
+				days: months[key].days
+			}))
+		},
+		days: {
+			values: dayValues,
+			daysPerYear: DAYS_PER_YEAR,
+			hoursPerDay: 24,
+			minutesPerHour: 60,
+			secondsPerMinute: 60
+		},
+		seasons: {
+			values: Object.entries(seasons).map(([key, season]) => ({
+				name: `DOLMEN.Calendar.Seasons.${key}`,
+				monthStart: monthKeys.indexOf(season.months[0]) + 1,
+				monthEnd: monthKeys.indexOf(season.months[season.months.length - 1]) + 1
+			}))
+		}
+	}
+}

--- a/module/calendar/calendar-data.js
+++ b/module/calendar/calendar-data.js
@@ -13,6 +13,19 @@ export class DolmenwoodCalendar extends foundry.data.CalendarData {
 		components.dayOfWeek = components.dayOfMonth < 28 ? components.dayOfMonth % 7 : 7
 		return components
 	}
+
+	/**
+	 * Timestamp formatter that displays the in-world year (yearZero + elapsed
+	 * years) instead of the raw years-since-epoch count, e.g. 1089-01-01
+	 * rather than 0000-01-01. Adding yearZero keeps this correct for any
+	 * calendar, so registering it as the global "timestamp" formatter leaves
+	 * yearZero-0 calendars (e.g. the earth calendar) unchanged.
+	 * @override
+	 */
+	static formatTimestamp(calendar, components, options) {
+		const display = { ...components, year: components.year + calendar.years.yearZero }
+		return super.formatTimestamp(calendar, display, options)
+	}
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "foundry-dolmenwood",
+  "name": "dolmenwood-foundry-system",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fairly minor changes. These modifications make the dolmenwood system built in calendar app store its time into the core foundry time system so that external modules/macros can access time data.
This opens up things like:

`game.time.components`

```
game.time.calendar.format(game.time.worldTime, "timestamp")
'1111-02-01 08:00:00'
```

```
(c => `${c.dayOfMonth + 1}-${game.i18n.localize(game.time.calendar.months.values[c.month].name)}-${c.year + game.time.calendar.years.yearZero}`)(game.time.components)
'1-Lymewald-1111'
```


Previously these would report gregarion time settings.

Note that due to the oddness of Wysendays in Dolmenwood, game.time will just report wysenday day names as "Wysenday" rather then a unique name for each day. Core Dolmenwood calendar remains unchanged.

All changes should migrate existing worlds without breakage.
